### PR TITLE
Add frame comparison project skeleton

### DIFF
--- a/frame_compare_app/main.py
+++ b/frame_compare_app/main.py
@@ -1,0 +1,65 @@
+"""Simple GUI example to display the first frame of two videos."""
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+import cv2
+from PyQt5 import QtGui, QtWidgets
+
+from modules.video_manager import VideoManager
+
+
+def frame_to_qimage(frame) -> QtGui.QImage:
+    """Convert an OpenCV frame (BGR) to QImage."""
+    rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+    h, w, ch = rgb.shape
+    bytes_per_line = ch * w
+    return QtGui.QImage(rgb.data, w, h, bytes_per_line, QtGui.QImage.Format_RGB888)
+
+
+class MainWindow(QtWidgets.QMainWindow):
+    def __init__(self, video_a: VideoManager, video_b: VideoManager) -> None:
+        super().__init__()
+        self.video_a = video_a
+        self.video_b = video_b
+        self._init_ui()
+        self.show_first_frames()
+
+    def _init_ui(self) -> None:
+        self.setWindowTitle("Frame Compare")
+        central = QtWidgets.QWidget()
+        self.setCentralWidget(central)
+        layout = QtWidgets.QHBoxLayout(central)
+        self.label_a = QtWidgets.QLabel("Video A")
+        self.label_b = QtWidgets.QLabel("Video B")
+        layout.addWidget(self.label_a)
+        layout.addWidget(self.label_b)
+
+    def show_first_frames(self) -> None:
+        frame_a = self.video_a.get_frame(0)
+        frame_b = self.video_b.get_frame(0)
+        if frame_a:
+            img_a = frame_to_qimage(frame_a[1])
+            self.label_a.setPixmap(QtGui.QPixmap.fromImage(img_a))
+        if frame_b:
+            img_b = frame_to_qimage(frame_b[1])
+            self.label_b.setPixmap(QtGui.QPixmap.fromImage(img_b))
+
+
+def main(path_a: str, path_b: str) -> None:
+    video_a = VideoManager(path_a)
+    video_b = VideoManager(path_b)
+    app = QtWidgets.QApplication(sys.argv)
+    win = MainWindow(video_a, video_b)
+    win.show()
+    app.exec_()
+    video_a.release()
+    video_b.release()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print("Usage: python main.py <video1> <video2>")
+        sys.exit(1)
+    main(sys.argv[1], sys.argv[2])

--- a/frame_compare_app/modules/comparison.py
+++ b/frame_compare_app/modules/comparison.py
@@ -1,0 +1,3 @@
+"""Frame comparison utilities."""
+
+# Placeholder for frame comparison logic

--- a/frame_compare_app/modules/frame_display.py
+++ b/frame_compare_app/modules/frame_display.py
@@ -1,0 +1,3 @@
+"""Utilities to display frames in the GUI."""
+
+# Placeholder for frame display logic

--- a/frame_compare_app/modules/gui.py
+++ b/frame_compare_app/modules/gui.py
@@ -1,0 +1,3 @@
+"""GUI components and widgets."""
+
+# Placeholder for GUI helper classes

--- a/frame_compare_app/modules/keyboard.py
+++ b/frame_compare_app/modules/keyboard.py
@@ -1,0 +1,3 @@
+"""Keyboard interaction utilities."""
+
+# Placeholder for keyboard handling logic

--- a/frame_compare_app/modules/metadata.py
+++ b/frame_compare_app/modules/metadata.py
@@ -1,0 +1,3 @@
+"""Utilities to read and display metadata."""
+
+# Placeholder for metadata extraction

--- a/frame_compare_app/modules/playback.py
+++ b/frame_compare_app/modules/playback.py
@@ -1,0 +1,3 @@
+"""Playback related functionality."""
+
+# Placeholder for playback control logic

--- a/frame_compare_app/modules/utils.py
+++ b/frame_compare_app/modules/utils.py
@@ -1,0 +1,3 @@
+"""General utility functions."""
+
+# Placeholder for helper utilities

--- a/frame_compare_app/modules/video_manager.py
+++ b/frame_compare_app/modules/video_manager.py
@@ -1,0 +1,33 @@
+"""Video loading and frame extraction utilities."""
+
+import cv2
+from typing import Optional, Tuple
+
+
+class VideoManager:
+    """Simple wrapper around cv2.VideoCapture."""
+
+    def __init__(self, path: str) -> None:
+        self.path = path
+        self.cap = cv2.VideoCapture(path)
+        if not self.cap.isOpened():
+            raise IOError(f"Cannot open video file: {path}")
+
+    def frame_count(self) -> int:
+        return int(self.cap.get(cv2.CAP_PROP_FRAME_COUNT))
+
+    def fps(self) -> float:
+        return float(self.cap.get(cv2.CAP_PROP_FPS))
+
+    def get_frame(self, index: int) -> Optional[Tuple[bool, any]]:
+        """Return frame at given index (0-based)."""
+        if index < 0 or index >= self.frame_count():
+            return None
+        self.cap.set(cv2.CAP_PROP_POS_FRAMES, index)
+        ret, frame = self.cap.read()
+        if not ret:
+            return None
+        return ret, frame
+
+    def release(self) -> None:
+        self.cap.release()


### PR DESCRIPTION
## Summary
- set up `frame_compare_app` project structure
- add starter `video_manager` module to load videos and extract frames
- add simple PyQt5 GUI in `main.py` to show the first frame from two videos
- add placeholder modules for future features

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68710edd37408322964188a745867127